### PR TITLE
swap url links in the readme.md file from the 'aws-fundamentals' sub-folder: to match the content-description

### DIFF
--- a/aws-fundamentals/README.md
+++ b/aws-fundamentals/README.md
@@ -28,8 +28,8 @@ We are excited to have you on this journey and look forward to supporting you in
 
 ## Warning about SkillBuilder links
 The SkillBuilder site has very strange behavior with referer handling.  
-So you will be correctly redirected if you click at SkillBuilder link from https://github.com/rolling-scopes-school/aws/aws-fundamentals.  
-But you will get 403 error page if you click SkillBuilder link from https://github.com/rolling-scopes-school/aws/blob/main/aws-fundamentals/README.md.  
+So you will be correctly redirected if you click at SkillBuilder link from https://github.com/rolling-scopes-school/aws/blob/main/aws-fundamentals/README.md.
+But you will get 404 error page if you click SkillBuilder link from https://github.com/rolling-scopes-school/aws/aws-fundamentals.
 
 ## Schedule
 


### PR DESCRIPTION
Hi,

The link:
[ https://github.com/rolling-scopes-school/aws/blob/main/aws-fundamentals/README.md ]

seemed misplaced in the description. So, in order to match the content description, i swapped it in the right place.