### PR TITLE
chore: update course rules link in README.md

### DIFF
--- a/aws-fundamentals/README.md
+++ b/aws-fundamentals/README.md
@@ -38,7 +38,7 @@ https://app.rs.school/course/schedule?course=aws-fundamentals-2024q4
 
 ### Week#1
 - Register on the platform: https://app.rs.school/registry/student?course=aws-fundamentals-2024q4
-- Familiarize yourself with the course rules: https://docs.rs.school/#/en/ 
+- Familiarize yourself with the course rules: https://rs.school/docs
 - Join the discord chat: https://discord.gg/uWvFU2RAba  
 - Self study: https://learn.cantrill.io/p/tech-fundamentals - 9h  
 


### PR DESCRIPTION
## Description
Updated the course rules link as the current one was directing the user to 404 page

## Screenshots
Before
<img width="1502" height="891" alt="Screenshot 2026-03-03 at 13 04 17" src="https://github.com/user-attachments/assets/c1bde0ae-03e3-4970-adab-2039e3c7232d" />

After
<img width="1502" height="891" alt="Screenshot 2026-03-03 at 13 04 26" src="https://github.com/user-attachments/assets/a655a1ab-8b86-4a0e-8f24-9ab55876a40a" />

