### PR TITLE
[AWS Developer] Format project tree in task 3 

### DIFF
--- a/aws-developer/03_serverless_api/task.md
+++ b/aws-developer/03_serverless_api/task.md
@@ -8,6 +8,7 @@
 - **Configure** credentials for AWS to make them accessible by AWS CLI & CDK.
 - **Create** your **own public Github repository** for all future backend work (you might call it how you would like). You will have 2 repos - 1 for frontend, 1 for backend till the end of course.
 Desired working tree should look somehow like this:
+```
 ├── backend
 │   ├── authorization_service <- auth service repo
 │   ├── import_service        <- import service repo
@@ -15,6 +16,7 @@ Desired working tree should look somehow like this:
 ├── cart_service              <- cart service repo
 │   ├── nodejs-aws-cart-api
 └── frontend                  <- frontend repo
+```
 
 _NOTE: You should create branch from master and work in branch (f.e. branch name - task-3) in BE (backend) and in FE (frontend) repositories._
 


### PR DESCRIPTION
The project tree in task 3 for the AVS developer was displaying incorrectly. This issue has been fixed in this pull request.
1. Before
<img width="1404" height="564" alt="Screenshot from 2026-04-29 16-34-35" src="https://github.com/user-attachments/assets/6328a544-30b1-4c82-a9a5-d1d134795c75" />
2. After:
<img width="1423" height="624" alt="Screenshot from 2026-04-29 16-35-37" src="https://github.com/user-attachments/assets/c04362b1-4281-4925-a4c9-53d6f0b7c0e1" />
